### PR TITLE
Adding maas formula

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,7 +61,7 @@ export FORMULAS_PATH=${FORMULAS_PATH:-/usr/share/salt-formulas}
 export FORMULAS_BRANCH=${FORMULAS_BRANCH:-master}
 export FORMULAS_SOURCE=${FORMULAS_SOURCE:-pkg} # pkg/git
 # essential set of formulas (known to by used on cfg01 node for most setups)
-FORMULAS_SALT_MASTER=${FORMULAS_SALT_MASTER:- $EXTRA_FORMULAS memcached openssh ntp nginx collectd sensu heka sphinx mysql grafana libvirt rsyslog glusterfs postfix xtrabackup freeipa prometheus telegraf elasticsearch kibana rundeck devops-portal rsync docker keepalived aptly jenkins gerrit artifactory influxdb horizon}
+FORMULAS_SALT_MASTER=${FORMULAS_SALT_MASTER:- $EXTRA_FORMULAS maas memcached openssh ntp nginx collectd sensu heka sphinx mysql grafana libvirt rsyslog glusterfs postfix xtrabackup freeipa prometheus telegraf elasticsearch kibana rundeck devops-portal rsync docker keepalived aptly jenkins gerrit artifactory influxdb horizon}
 # minimal set of formulas for salt-master bootstrap
 declare -a FORMULAS_SALT_MASTER=(linux reclass salt git $(echo $FORMULAS_SALT_MASTER))
 export FORMULAS_SALT_MASTER


### PR DESCRIPTION
Without the "maas" formula I'm getting the following error when running ```bootstrap.sh```:

```
$ MASTER_HOSTNAME=cfg01.test.local ./bootstrap.sh
...
...
...
[INFO] State: salt.master.env 
+ salt-call --timeout=120 --state-output=changes --retcode-passthrough --force-color --state-verbose=false -lerror -linfo state.apply salt.master.env 'pillar={"salt":{"master":{"pillar":{"reclass":{"ignore_class_notfound": "False"}}}}, "reclass":{"storage":{"data_source":{"engine":"local"}}} }'
local:
    Data failed to compile:
----------
    Pillar failed to render with the following messages:
----------
    Failed to load ext_pillar reclass: ext_pillar.reclass: 
+ log_err 'State salt.master.env failed, keep your eyes wide open.'
+ echo -e '\033[0;31m[ERROR] State salt.master.env failed, keep your eyes wide open. \033[0m'
[ERROR] State salt.master.env failed, keep your eyes wide open. 
```